### PR TITLE
Fix build on newer Node.js and on Windows.

### DIFF
--- a/build.js
+++ b/build.js
@@ -25,7 +25,7 @@ function fail (err) {
 }
 
 function basePath (file) {
-  return path.relative(SUITE_DIR, file)
+  return path.relative(SUITE_DIR, file).replace(/\\/g, '/')
 }
 
 function writeManifest (fileList) {
@@ -40,7 +40,7 @@ function writeManifest (fileList) {
   }
   code.push(']')
   var codeStr = code.join('')
-  fs.writeFile('./node-test/index.js', codeStr)
+  fs.writeFileSync('./node-test/index.js', codeStr)
   console.log('done!')
 }
 
@@ -70,7 +70,7 @@ function build () {
           if (str) {
             var fileName = result.caseName
             fileList.push(fileName)
-            fs.writeFile(path.join(TEST_DIR, fileName) + '.js', str)
+            fs.writeFileSync(path.join(TEST_DIR, fileName) + '.js', str)
           }
           decCount()
         }

--- a/lib/compile-case.js
+++ b/lib/compile-case.js
@@ -39,7 +39,7 @@ function generateShell (suiteDir, data) {
     'ENVIRONMENT.scriptList=', JSON.stringify(data.shaders), ';',
     'ENVIRONMENT.canvasList=', JSON.stringify(data.canvas), '.map(function(opts){return _canvasShim(ENVIRONMENT,opts);});',
     'ENVIRONMENT.RESOURCES=_RESOURCES;',
-    'ENVIRONMENT.BASEPATH="', path.relative(suiteDir, data.directory), '";',
+    'ENVIRONMENT.BASEPATH="', path.relative(suiteDir, data.directory).replace(/\\/g, '/'), '";',
     'var document=ENVIRONMENT.document;',
     'var window=ENVIRONMENT.window;',
     'var Image=_imageShim;',

--- a/lib/parse-case.js
+++ b/lib/parse-case.js
@@ -32,7 +32,7 @@ function parseTestCase (VERSION, file, cb) {
   tr.selectAll('script', function (elem) {
     var src = elem.getAttribute('src')
     if (src) {
-      var relpath = path.relative(root, path.resolve(path.join(dirname, src)))
+      var relpath = path.relative(root, path.resolve(path.join(dirname, src))).replace(/\\/g, '/')
       srcTags.push(relpath)
     } else {
       var type = elem.getAttribute('type') || elem.getAttribute('language')

--- a/lib/scan-files.js
+++ b/lib/scan-files.js
@@ -4,6 +4,7 @@ module.exports = globTestCases
 
 var path = require('path')
 var fs = require('fs')
+var os = require('os')
 
 function globTestCases (VERSION, cb) {
   var rootFile = path.join(__dirname, '../conformance-suites', VERSION, '00_test_list.txt')
@@ -40,7 +41,7 @@ function globTestCases (VERSION, cb) {
         return
       }
       var root = path.dirname(list)
-      var lines = data.toString().split('\n')
+      var lines = data.toString().split(os.EOL)
       for (var i = 0; i < lines.length; ++i) {
         var toks = lines[i].split(' ')
         if (toks.length === 0 || toks[0].indexOf('#') === 0) {

--- a/lib/shims/canvas-shim.js
+++ b/lib/shims/canvas-shim.js
@@ -24,7 +24,9 @@ proto.getContext = function (type, options) {
       this._width,
       this._height,
       options)
-    gl.canvas = this
+    if (!Object.hasOwn(gl, 'canvas')) {
+      gl.canvas = this
+    }
     this._gl = gl
   }
   if (type === 'webgl' || type === 'experimental-webgl') {

--- a/lib/shims/webgl-test-utils.js
+++ b/lib/shims/webgl-test-utils.js
@@ -1063,7 +1063,9 @@ var create3DContext = function(opt_canvas, opt_attributes) {
           width  = canvasList[i].width  || 500
           height = canvasList[i].height || 500
           var ctx = ENVIRONMENT.createContext(width, height, opt_attributes)
-          ctx.canvas     = canvasList[i]
+          if (!Object.hasOwn(ctx, 'canvas')) {
+            ctx.canvas = canvasList[i]
+          }
           ctx.canvas._gl = ctx
           canvas = ctx.canvas
           return ctx
@@ -1073,7 +1075,9 @@ var create3DContext = function(opt_canvas, opt_attributes) {
       width  = opt_canvas.width  || 512
       height = opt_canvas.height || 512
       var ctx = ENVIRONMENT.createContext(width, height, opt_attributes)
-      ctx.canvas     = opt_canvas
+      if (!Object.hasOwn(ctx, 'canvas')) {
+        ctx.canvas = opt_canvas
+      }
       ctx.canvas._gl = ctx
       canvas = ctx.canvas
       return ctx
@@ -1081,7 +1085,9 @@ var create3DContext = function(opt_canvas, opt_attributes) {
   }
   var ctx        = ENVIRONMENT.createContext(width, height, opt_attributes)
   canvas     = document.createElement("canvas")
-  ctx.canvas     = canvas
+  if (!Object.hasOwn(ctx, 'canvas')) {
+    ctx.canvas = canvas
+  }
   ctx.canvas._gl = ctx
   return ctx
 }


### PR DESCRIPTION
Replaces calls to writeFile with writeFileSync, and fixes some path separator instances where Windows was getting confused. Also allows the example to run by omitting the write to ctx.canvas if it's already defined.
